### PR TITLE
chore: remove direct dependency on "cdk8s" and "constructs"

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -11,10 +11,6 @@ const project = new JsiiProject({
   repository: 'https://github.com/iliapolo/stdk8s.git',
   authorName: 'Eli Polonsky',
   authorEmail: 'epolon@amazon.com',
-  dependencies: {
-    constructs: constructsDependency,
-    cdk8s: cdk8sDependency,
-  },
   peerDependencies: {
     constructs: constructsDependency,
     cdk8s: cdk8sDependency,

--- a/package.json
+++ b/package.json
@@ -52,10 +52,7 @@
     "constructs": "^2.0.1",
     "cdk8s": "^0.25.0"
   },
-  "dependencies": {
-    "constructs": "^2.0.1",
-    "cdk8s": "^0.25.0"
-  },
+  "dependencies": {},
   "bundledDependencies": [],
   "license": "Apache-2.0",
   "version": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,7 +1116,7 @@ cdk8s@0.21.0:
     json-stable-stringify "^1.0.1"
     yaml "^1.7.2"
 
-cdk8s@^0.25.0:
+cdk8s@0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-0.25.0.tgz#60e1eed0990a631b286d04a4033d19f0c21ed463"
   integrity sha512-9Vyukkb/NwHtXLQ9lZqGqD8N37iOr2ikNX2rnKHavB7bBfoAwOsgsVBa6gzhMdXbVZplmd6vDJ0L/KChr6ZauQ==


### PR DESCRIPTION
These modules have types that we expose through public API, so they must only be defined as peer dependencies.