### PR TITLE
feat: additional capabilities for "PodSpec" and "Container"

### DIFF
--- a/lib/model/container.ts
+++ b/lib/model/container.ts
@@ -1,14 +1,23 @@
 import * as model from '../model';
 
 export interface ContainerProps {
-
   readonly image: string;
 
-  readonly name: string;
+  /**
+   * @default "main"
+   */
+  readonly name?: string;
 
-  // TODO: make this an array of structs (see k8s#ContainerPort)
-  readonly port: number
+  /**
+   * // TODO: make this an array of structs (see k8s#ContainerPort)
+   * @default - on port is exposed
+   */
+  readonly port?: number
 
+  /**
+   * The command to execute
+   */
+  readonly command?: string[];
 }
 
 export class Container {
@@ -16,16 +25,17 @@ export class Container {
   public readonly volumeMounts: model.VolumeMount[] = [];
   public readonly name: string;
   public readonly image: string;
-  public readonly port: number;
+  public readonly port?: number;
+  public readonly command?: string[];
 
   constructor(props: ContainerProps) {
-    this.name = props.name;
+    this.name = props.name ?? 'main';
     this.image = props.image;
     this.port = props.port;
+    this.command = props.command;
   }
 
   public mount(options: model.VolumeMount) {
     this.volumeMounts.push(options);
   }
-
 }

--- a/lib/spec/pod.ts
+++ b/lib/spec/pod.ts
@@ -7,16 +7,27 @@ export interface PodSpecProps {
 
   readonly volumes?: model.Volume[];
 
+  /**
+   * @default RestartPolicy.ALWAYS
+   */
+  readonly restartPolicy?: RestartPolicy;
+
+export enum RestartPolicy {
+  ALWAYS = 'Always',
+  ON_FAILURE = 'OnFailure',
+  NEVER = 'Never'
 }
 
 export class PodSpec {
 
   public containers: model.Container[];
   public volumes: model.Volume[];
+  public restartPolicy?: RestartPolicy;
 
   constructor(props: PodSpecProps = {}) {
     this.containers = props.containers ?? [];
     this.volumes = props.volumes ?? [];
+    this.restartPolicy = props.restartPolicy;
   }
 
   public addContainer(container: model.Container): void {
@@ -59,17 +70,25 @@ export class PodSpec {
         })
       }
 
+      const ports = new Array();
+
       containers.push({
         name: container.name,
         image: container.image,
-        ports: [{
-          containerPort: container.port,
-        }],
+        ports: ports,
         volumeMounts: volumeMounts,
-      })
+        command: container.command,
+      });
+
+      if (container.port) {
+        ports.push({
+          containerPort: container.port,
+        });
+      }
     }
 
     return {
+      restartPolicy: this.restartPolicy,
       containers: containers,
       volumes: volumes,
     }


### PR DESCRIPTION
Container:
- make `name` optional (default to "main").
- make `port` optional (default to no port is exposed)
- Add `command`

PodSpec:
- add `restartPolicy`